### PR TITLE
Fixed exit code on lint violations.

### DIFF
--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -90,7 +90,6 @@ class LintCommand extends Command {
       $processed_lines[] = $is_running_fix ? $processed_line : $line;
     }
 
-    // Do actual replace variables in file or not.
     if ($is_running_fix) {
       $file_data = implode('', $processed_lines);
       file_put_contents($file_name, $file_data);
@@ -98,6 +97,7 @@ class LintCommand extends Command {
     }
     else {
       $result['messages'][] = sprintf('Found %s variables in file "%s" that are not wrapped in ${}.', $changed_count, $file_name);
+      $result['success'] = $changed_count === 0;
     }
 
     return $result;

--- a/tests/phpunit/Functional/LintFunctionalTest.php
+++ b/tests/phpunit/Functional/LintFunctionalTest.php
@@ -23,22 +23,31 @@ class LintFunctionalTest extends FunctionalTestCase {
    */
   public function testLintCommand(): void {
     $command = new LintCommand();
-    // No existing file.
+
+    // Not existing file.
     $output = $this->runExecute($command, ['file' => 'no-existing-file.sh']);
     $this->assertEquals('Could not open file no-existing-file.sh' . PHP_EOL, implode(PHP_EOL, $output));
+    $this->assertEquals(1, $this->commandTester->getStatusCode());
+
     // Valid file.
     $valid_file = $this->createTempFileFromFixtureFile('wrapped.sh');
     $valid_file_not_run = $this->createTempFileFromFixtureFile('wrapped.sh');
     $this->assertFileEquals($valid_file, $valid_file_not_run);
+
     $output = $this->runExecute($command, ['file' => $valid_file]);
+    $this->assertEquals(0, $this->commandTester->getStatusCode());
     $this->assertEquals(sprintf('Found 0 variables in file "%s" that are not wrapped in ${}.', $valid_file) . PHP_EOL, implode(PHP_EOL, $output));
+
     $output = $this->runExecute($command, ['file' => $valid_file, '-f' => TRUE]);
+    $this->assertEquals(0, $this->commandTester->getStatusCode());
     $this->assertEquals(sprintf('Replaced 0 variables in file "%s".', $valid_file) . PHP_EOL, implode(PHP_EOL, $output));
     $this->assertFileEquals($valid_file, $valid_file_not_run);
+
     // Invalid file.
     $invalid_file = $this->createTempFileFromFixtureFile('unwrapped.sh');
     $invalid_file_not_run = $this->createTempFileFromFixtureFile('unwrapped.sh');
     $this->assertFileEquals($invalid_file, $invalid_file_not_run);
+
     $output = $this->runExecute($command, ['file' => $invalid_file]);
     $this->assertEquals([
       '11: var=$VAR1',
@@ -47,6 +56,8 @@ class LintFunctionalTest extends FunctionalTestCase {
       sprintf('Found 3 variables in file "%s" that are not wrapped in ${}.', $invalid_file),
       '',
     ], $output);
+    $this->assertEquals(1, $this->commandTester->getStatusCode());
+
     $output = $this->runExecute($command, ['file' => $invalid_file, '-f' => TRUE]);
     $this->assertEquals([
       'Replaced in line 11: var=$VAR1',
@@ -56,6 +67,7 @@ class LintFunctionalTest extends FunctionalTestCase {
       '',
     ], $output);
     $this->assertFileNotEquals($invalid_file, $invalid_file_not_run);
+    $this->assertEquals(0, $this->commandTester->getStatusCode());
   }
 
 }

--- a/tests/phpunit/Unit/LintUnitTest.php
+++ b/tests/phpunit/Unit/LintUnitTest.php
@@ -33,7 +33,7 @@ class LintUnitTest extends UnitTestBase {
     // Test invalid file.
     $invalidFile = $this->createTempFileFromFixtureFile('unwrapped.sh');
     $result = $lintCommand->processFile($invalidFile);
-    $this->assertEquals(TRUE, $result['success']);
+    $this->assertEquals(FALSE, $result['success']);
     $this->assertEquals([
       "11: var=\$VAR1",
       "12: var=\"\$VAR2\"",


### PR DESCRIPTION
Running `lint` on files with violations now returns a non-zero exit code.