### PR TITLE
Add ability to ignore lint violations with inline directives

### DIFF
--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -94,7 +94,37 @@ class LintCommand extends Command {
     // Process lines.
     $processed_lines = [];
     $changed_count = 0;
+    $ignore_next_line = FALSE;
+    $ignore_block = FALSE;
     foreach ($lines as $k => $line) {
+      $trimmed = trim($line);
+
+      // Check for ignore directives.
+      if (preg_match('/^#\s*shellvar-ignore-next-line\s*$/', $trimmed)) {
+        $ignore_next_line = TRUE;
+        $processed_lines[] = $line;
+        continue;
+      }
+
+      if (preg_match('/^#\s*shellvar-ignore-start\s*$/', $trimmed)) {
+        $ignore_block = TRUE;
+        $processed_lines[] = $line;
+        continue;
+      }
+
+      if (preg_match('/^#\s*shellvar-ignore-end\s*$/', $trimmed)) {
+        $ignore_block = FALSE;
+        $processed_lines[] = $line;
+        continue;
+      }
+
+      // Skip processing if line is ignored.
+      if ($ignore_next_line || $ignore_block) {
+        $ignore_next_line = FALSE;
+        $processed_lines[] = $line;
+        continue;
+      }
+
       $processed_line = $this->processLine($line);
       $line_number = $k + 1;
       if ($processed_line !== $line) {

--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -108,12 +108,14 @@ class LintCommand extends Command {
 
       if (preg_match('/^#\s*shellvar-ignore-start\s*$/', $trimmed)) {
         $ignore_block = TRUE;
+        $ignore_next_line = FALSE;
         $processed_lines[] = $line;
         continue;
       }
 
       if (preg_match('/^#\s*shellvar-ignore-end\s*$/', $trimmed)) {
         $ignore_block = FALSE;
+        $ignore_next_line = FALSE;
         $processed_lines[] = $line;
         continue;
       }

--- a/tests/phpunit/Fixtures/unwrapped-ignore-edge-cases.sh
+++ b/tests/phpunit/Fixtures/unwrapped-ignore-edge-cases.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+##
+# Test ignore directive edge cases.
+#
+
+# Edge case 1: ignore-next-line followed by ignore block.
+# The next-line flag should be cleared by the block start.
+# shellvar-ignore-next-line
+# shellvar-ignore-start
+var=$VAR1
+# shellvar-ignore-end
+var=$VAR2
+
+# Edge case 2: ignore-next-line before ignore block end.
+# shellvar-ignore-start
+var=$VAR3
+# shellvar-ignore-next-line
+# shellvar-ignore-end
+var=$VAR4
+
+# Edge case 3: consecutive ignore-next-line directives.
+# Only the last one should apply (to the next non-directive line).
+# shellvar-ignore-next-line
+# shellvar-ignore-next-line
+var=$VAR5
+var=$VAR6

--- a/tests/phpunit/Fixtures/unwrapped-ignore-fixed.sh
+++ b/tests/phpunit/Fixtures/unwrapped-ignore-fixed.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+##
+# Test ignore directives.
+#
+
+VAR1=1
+var=${VAR1}
+# shellvar-ignore-next-line
+var=$VAR2
+var=${VAR3}
+# shellvar-ignore-start
+var=$VAR4
+var=$VAR5
+# shellvar-ignore-end
+var=${VAR6}

--- a/tests/phpunit/Fixtures/unwrapped-ignore.sh
+++ b/tests/phpunit/Fixtures/unwrapped-ignore.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+##
+# Test ignore directives.
+#
+
+VAR1=1
+var=$VAR1
+# shellvar-ignore-next-line
+var=$VAR2
+var=$VAR3
+# shellvar-ignore-start
+var=$VAR4
+var=$VAR5
+# shellvar-ignore-end
+var=$VAR6

--- a/tests/phpunit/Unit/LintUnitTest.php
+++ b/tests/phpunit/Unit/LintUnitTest.php
@@ -98,6 +98,31 @@ class LintUnitTest extends UnitTestBase {
   }
 
   /**
+   * Test ignore directive edge cases.
+   *
+   * Covers: ignore-next-line before block, ignore-next-line inside block,
+   * and consecutive ignore-next-line directives.
+   *
+   * @throws \Exception
+   */
+  public function testProcessFileIgnoreDirectivesEdgeCases(): void {
+    $lint_command = new LintCommand();
+
+    $ignore_file = $this->createTempFileFromFixtureFile('unwrapped-ignore-edge-cases.sh');
+    $result = $lint_command->processFile($ignore_file);
+    $this->assertEquals(FALSE, $result['success']);
+    // VAR1 ignored (in block), VAR2 reported (line 12).
+    // VAR3 ignored (in block), VAR4 reported (line 19).
+    // VAR5 ignored (next-line), VAR6 reported (line 26).
+    $this->assertEquals([
+      "12: var=\$VAR2",
+      "19: var=\$VAR4",
+      "26: var=\$VAR6",
+      sprintf('Found 3 variables in file "%s" that are not wrapped in ${}.', $ignore_file),
+    ], $result['messages']);
+  }
+
+  /**
    * Test process line text.
    *
    * @param string $text

--- a/tests/phpunit/Unit/LintUnitTest.php
+++ b/tests/phpunit/Unit/LintUnitTest.php
@@ -61,6 +61,43 @@ class LintUnitTest extends UnitTestBase {
   }
 
   /**
+   * Test process file with ignore directives.
+   *
+   * @throws \Exception
+   */
+  public function testProcessFileIgnoreDirectives(): void {
+    $lint_command = new LintCommand();
+
+    // Test ignore directives - lint mode.
+    $ignore_file = $this->createTempFileFromFixtureFile('unwrapped-ignore.sh');
+    $result = $lint_command->processFile($ignore_file);
+    $this->assertEquals(FALSE, $result['success']);
+    // Lines 7, 10, 15 should be reported (VAR1, VAR3, VAR6).
+    // Lines 9 (ignore-next-line), 12-13 (ignore block) should be skipped.
+    $this->assertEquals([
+      "7: var=\$VAR1",
+      "10: var=\$VAR3",
+      "15: var=\$VAR6",
+      sprintf('Found 3 variables in file "%s" that are not wrapped in ${}.', $ignore_file),
+    ], $result['messages']);
+
+    // Test ignore directives - fix mode.
+    $ignore_file_fix = $this->createTempFileFromFixtureFile('unwrapped-ignore.sh', 'fix');
+    $result = $lint_command->processFile($ignore_file_fix, TRUE);
+    $this->assertEquals(TRUE, $result['success']);
+    $this->assertEquals([
+      "Replaced in line 7: var=\$VAR1",
+      "Replaced in line 10: var=\$VAR3",
+      "Replaced in line 15: var=\$VAR6",
+      sprintf('Replaced 3 variables in file "%s".', $ignore_file_fix),
+    ], $result['messages']);
+
+    // Verify the fixed file matches expectation.
+    $expected_file = static::fixtureFile('unwrapped-ignore-fixed.sh');
+    $this->assertFileEquals($expected_file, $ignore_file_fix);
+  }
+
+  /**
    * Test process line text.
    *
    * @param string $text


### PR DESCRIPTION
Adds support for inline ignore directives in the lint command:

- `# shellvar-ignore-next-line` — skips the immediately following line
- `# shellvar-ignore-start` / `# shellvar-ignore-end` — skips all lines within the block

Ignored lines are preserved as-is in both lint and fix modes.

### Example

```bash
# This will be reported:
var=$VAR1

# shellvar-ignore-next-line
var=$VAR2  # This is ignored

# shellvar-ignore-start
var=$VAR3  # Ignored
var=$VAR4  # Ignored
# shellvar-ignore-end

var=$VAR5  # This will be reported
```

### Changes

- **`LintCommand::processFile()`** — detects ignore directives and skips flagged lines
- **Fixtures** — `unwrapped-ignore.sh` and `unwrapped-ignore-fixed.sh`
- **Unit test** — `testProcessFileIgnoreDirectives`
- **Functional test** — `testLintCommandFileIgnoreDirectives`

All 422 tests pass.

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request introduces inline ignore directives for the lint command, enabling developers to selectively suppress linting violations for specific lines or code blocks.

## Changes

**Core Implementation** (`src/Command/LintCommand.php`):
- Modified `processFile()` to detect and handle three ignore directives:
  - `# shellvar-ignore-next-line` — skips the immediately following line
  - `# shellvar-ignore-start` / `# shellvar-ignore-end` — skips all lines within the block
- Tracks ignore state (`ignore_next_line`, `ignore_block`) and preserves ignored lines verbatim without processing via `processLine()`, so ignored content remains unchanged in both lint and fix modes.
- Ensures `ignore_next_line` is correctly reset when entering/exiting ignore blocks to avoid unintended persistence.

**Test Coverage & Fixtures**:
- Unit tests:
  - `testProcessFileIgnoreDirectives()` — validates normal ignore behavior in lint and fix modes.
  - `testProcessFileIgnoreDirectivesEdgeCases()` — covers edge cases (ignore-next-line before block, inside block, consecutive ignore-next-line directives).
  - File: `tests/phpunit/Unit/LintUnitTest.php`
- Functional test:
  - `testLintCommandFileIgnoreDirectives()` — end-to-end lint + fix behavior with directives.
  - File: `tests/phpunit/Functional/LintFunctionalTest.php`
- New fixtures:
  - `tests/phpunit/Fixtures/unwrapped-ignore.sh`
  - `tests/phpunit/Fixtures/unwrapped-ignore-fixed.sh`
  - `tests/phpunit/Fixtures/unwrapped-ignore-edge-cases.sh`

## Testing

All 422 tests pass. New tests confirm:
- Lines and blocks marked with ignore directives are not reported as violations.
- Fix mode applies replacements only to non-ignored violations while preserving ignored lines.
- Fixed output matches expected fixtures.

## Related

Closes #65
<!-- end of auto-generated comment: release notes by coderabbit.ai -->